### PR TITLE
finish reek and rubocop fixes

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,6 @@
+exclude_paths:
+  - app/channels
+  - app/jobs
+  - app/mailers
+  - db/migrate
+  - spec/support

--- a/app/controllers/api/boxes_controller.rb
+++ b/app/controllers/api/boxes_controller.rb
@@ -9,40 +9,40 @@ module Api
 
     # GET /api/boxes
     def index
-      @boxes = Box.all
-      render json: @boxes, status: :ok
+      boxes = Box.all
+      render json: boxes, status: :ok
     end
 
     # GET /api/boxes/1
     def show
-      render json: @box, status: :ok
+      render json: box, status: :ok
     end
 
     # POST api/boxes
     def create
-      @box = Box.new(box_params)
-      if @box.save
-        render json: @box, status: :created
+      box = Box.new(box_params)
+      if box.save
+        render json: box, status: :created
       else
-        render json: @box.errors, status: :unprocessable_entity
+        render json: box.errors, status: :unprocessable_entity
       end
     end
 
     # PATCH /api/box/1
     def update
-      if @box.update(box_params)
-        render json: @box, status: :ok
+      if box.update(box_params)
+        render json: box, status: :ok
       else
-        render json: @box.errors, status: :unprocessable_entity
+        render json: box.errors, status: :unprocessable_entity
       end
     end
 
     # DELETE /api/box/1
     def destroy
-      if @box.destroy
-        render json: @box, status: :no_content
+      if box.destroy
+        render json: box, status: :no_content
       else
-        render json: @box.errors, status: :unprocessable_entity
+        render json: box.errors, status: :unprocessable_entity
       end
     end
 
@@ -55,5 +55,7 @@ module Api
     def box_params
       params.require(:box).permit(:name, :description)
     end
+
+    attr_reader :box, :boxes
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -6,7 +6,7 @@ module Api
     before_action :find_user, only: %w[show]
 
     def show
-      render_jsonapi_response(@user)
+      render_jsonapi_response(user)
     end
 
     private
@@ -14,5 +14,7 @@ module Api
     def find_user
       @user = User.find(params[:id])
     end
+
+    attr_accessor :user
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,10 +10,11 @@ class ApplicationController < ActionController::API
   respond_to :json
 
   def render_jsonapi_response(resource)
-    if resource.errors.empty?
+    errors = resource.errors
+    if errors.empty?
       render jsonapi: resource
     else
-      render jsonapi_errors: resource.errors, status: :bad_request
+      render jsonapi_errors: errors, status: :bad_request
     end
   end
 end

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Box model acts as both container and item for nested boxes
 class Box < ApplicationRecord
   validates :name, presence: true, uniqueness: true, allow_blank: false
   validates :box_type, presence: true, allow_blank: true

--- a/spec/support/api_helpers.rb
+++ b/spec/support/api_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Helper to log in for test auth
 module ApiHelpers
   def json
     JSON.parse(response.body)

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -3,6 +3,7 @@
 require 'faker'
 require 'factory_bot_rails'
 
+# Helpers for User request spec
 module UserHelpers
   # creates user in db
   def create_user


### PR DESCRIPTION
Add documentation comments and use attr_readers instead of directly using instance variables in controllers.

Reek and rubocop pass for existing code.